### PR TITLE
Add option to use Chanserv to set the topic

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -5,6 +5,9 @@ const BotNick = "foubot"
 const BotPswd = "HAHAHAHAHA, nope."
 const BotAutoVoice = false
 const ServerTLS = "irc.libera.chat:6697"
+// Set topic through chanserv instead of directly, avoids
+// the need for the +o mode but requires chanserv flag +t
+const TopicUseChanserv = true
 const StatusEndPoint = "https://foulab.org/YTDMOWI3N2MXNMEZYWE4MGRHYTRLMZC4NJU5MJI2ZJYYODMYNME5NSAGLQO/"
 const Blinker = "http://blinker.lab/"
 

--- a/ledsign/status.go
+++ b/ledsign/status.go
@@ -76,7 +76,11 @@ func processStatus(ss *SWITCHSTATE, nc *http.Client, irccon *irc.Connection) {
 					hold := strings.Split(ss.Topic, "||")
 					topic := fmt.Sprintf("%s|| LAB %s ||%s", hold[0], strStatus, hold[2])
 					if ss.Topic != topic {
-						irccon.Topic(BotChannel, topic)
+						if configuration.TopicUseChanserv {
+							irccon.Privmsg("ChanServ", fmt.Sprintf("TOPIC %s %s", configuration.BotChannel, topic))
+						} else {
+							irccon.Topic(BotChannel, topic)
+						}
 						ss.Topic = topic
 					}
 				}


### PR DESCRIPTION
This means foubot does not need to be op on the channel

Foubot already has the needed flag on `#foulab`