### PR TITLE
status: gate normal messages behind config

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -9,6 +9,9 @@ const ServerTLS = "irc.libera.chat:6697"
 // Set topic through chanserv instead of directly, avoids
 // the need for the +o mode but requires chanserv flag +t
 const TopicUseChanserv = true
+// Whether to send status updates as normal messages along
+// with updating the topic
+const TopicSendToChannel = false
 const StatusEndPoint = "https://foulab.org/YTDMOWI3N2MXNMEZYWE4MGRHYTRLMZC4NJU5MJI2ZJYYODMYNME5NSAGLQO/"
 const Blinker = "http://blinker.lab/"
 

--- a/ledsign/status.go
+++ b/ledsign/status.go
@@ -86,7 +86,7 @@ func processStatus(ss *SWITCHSTATE, nc *http.Client, irccon *irc.Connection) {
 				}
 
 				// IRC announcement (but not at startup, to avoid spam)
-				if !first {
+				if !first && configuration.TopicSendToChannel {
 					irccon.Privmsg(BotChannel, fmt.Sprintf("|| LAB %s ||", strStatus))
 				}
 


### PR DESCRIPTION
Alternatively, the code could just be removed outright.

I haven't got to test this yet